### PR TITLE
Installation instructions to include PHP's ZIP extension

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -20,6 +20,7 @@ However, if you are not using Homestead, you will need to make sure your server 
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension
+- Zip PHP Extension
 </div>
 
 <a name="installing-lumen"></a>


### PR DESCRIPTION
Updating installation.md to include requiring PHP's ZIP extension as it seems to be necessary for using the example command `lumen new blog`.

I suppose it is possible that this extension is not needed: I am finding it is needed when using lumen-installer 1.0.2 downloaded via composer on 2018 March 7. My host OS is Ubuntu 16.04.4 running PHP 7.1.15 which was installed using Ubutnu's apt-get utility.

This Laracasts page confirms the difficulty some have when the ZIP extension is not installed: https://laracasts.com/discuss/channels/laravel/zip-php-extension-problem-in-ubuntu-php7

I can imagine that this extension is not needed in situations that are different than mine (and those in the Laracasts discussion). So denying this PR may make sense.  But in case this is a good addition, here's the PR (grin).